### PR TITLE
Add InstanceLock to make sure that only one hyprsunset is running. Closes #10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ execute_process(
 #
 
 include_directories(.)
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 26)
 add_compile_options(
   -Wall
   -Wextra

--- a/src/IPCSemaphore.cpp
+++ b/src/IPCSemaphore.cpp
@@ -1,0 +1,32 @@
+#include <format>
+
+#include "helpers/Log.hpp"
+#include "IPCSemaphore.hpp"
+
+CIPCSemaphore::CIPCSemaphore(const char* semName) : pSemaphore(sem_open(semName, O_CREAT, 0666)) {
+    if (pSemaphore == SEM_FAILED) {
+        Debug::log(ERR, "✖ Failed to open semaphore");
+        pSemaphore = nullptr;
+    }
+}
+
+CIPCSemaphore::~CIPCSemaphore() noexcept {
+    sem_close(pSemaphore);
+}
+
+CIPCSemaphore::Lock CIPCSemaphore::getLock() noexcept {
+    return Lock{pSemaphore};
+}
+
+CIPCSemaphore::Lock::Lock(sem_t* semaphore) : pSemaphore(semaphore) {
+    if (!semaphore) {
+        Debug::log(ERR, "✖ Lock failed null semaphore");
+        return;
+    }
+    sem_wait(semaphore);
+}
+
+CIPCSemaphore::Lock::~Lock() noexcept {
+    if (pSemaphore)
+        sem_post(pSemaphore);
+}

--- a/src/IPCSemaphore.hpp
+++ b/src/IPCSemaphore.hpp
@@ -1,46 +1,25 @@
 #pragma once
 
-#include <format>
 #include <fcntl.h>
 #include <semaphore.h>
 
-#include "helpers/Log.hpp"
-
-class IPCSemaphore {
+class CIPCSemaphore {
   public:
     class Lock {
       public:
-        explicit Lock(sem_t* semaphore) : pSemaphore(semaphore) {
-            if (!semaphore) {
-                Debug::log(ERR, "✖ Lock failed null semaphore");
-                return;
-            }
-            sem_wait(semaphore);
-        }
-        ~Lock() noexcept {
-            if (pSemaphore)
-                sem_post(pSemaphore);
-        }
+        explicit Lock(sem_t* semaphore);
+        ~Lock() noexcept;
 
       private:
         sem_t* pSemaphore = nullptr;
     };
 
   public:
-    IPCSemaphore(const char* semName) : pSemaphore(sem_open(semName, O_CREAT, 0666)) {
-        if (pSemaphore == SEM_FAILED) {
-            Debug::log(ERR, "✖ Failed to open semaphore");
-            pSemaphore = nullptr;
-        }
-    }
+    CIPCSemaphore(const char* semName);
 
-    ~IPCSemaphore() noexcept {
-        sem_close(pSemaphore);
-    }
+    ~CIPCSemaphore() noexcept;
 
-    Lock getLock() noexcept {
-        return Lock{pSemaphore};
-    }
+    Lock getLock() noexcept;
 
   private:
     sem_t* pSemaphore = nullptr;

--- a/src/IPCSemaphore.hpp
+++ b/src/IPCSemaphore.hpp
@@ -38,7 +38,7 @@ class IPCSemaphore {
         sem_close(pSemaphore);
     }
 
-    Lock GetLock() noexcept {
+    Lock getLock() noexcept {
         return Lock{pSemaphore};
     }
 

--- a/src/IPCSemaphore.hpp
+++ b/src/IPCSemaphore.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <format>
+#include <fcntl.h>
+#include <semaphore.h>
+
+#include "helpers/Log.hpp"
+
+class IPCSemaphore {
+  public:
+    class Lock {
+      public:
+        explicit Lock(sem_t* semaphore) : pSemaphore(semaphore) {
+            if (!semaphore) {
+                Debug::log(ERR, "✖ Lock failed null semaphore");
+                return;
+            }
+            sem_wait(semaphore);
+        }
+        ~Lock() noexcept {
+            if (pSemaphore)
+                sem_post(pSemaphore);
+        }
+
+      private:
+        sem_t* pSemaphore = nullptr;
+    };
+
+  public:
+    IPCSemaphore(const char* semName) : pSemaphore(sem_open(semName, O_CREAT, 0666)) {
+        if (pSemaphore == SEM_FAILED) {
+            Debug::log(ERR, "✖ Failed to open semaphore");
+            pSemaphore = nullptr;
+        }
+    }
+
+    ~IPCSemaphore() noexcept {
+        sem_close(pSemaphore);
+    }
+
+    Lock GetLock() noexcept {
+        return Lock{pSemaphore};
+    }
+
+  private:
+    sem_t* pSemaphore = nullptr;
+};

--- a/src/InstanceLock.cpp
+++ b/src/InstanceLock.cpp
@@ -1,0 +1,138 @@
+#include "InstanceLock.hpp"
+
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <fstream>
+#include <filesystem>
+#include <iostream>
+#include <ranges>
+#include <thread>
+
+#include "helpers/Log.hpp"
+#include "helpers/GetRuntimeDir.hpp"
+
+#include "IPCSemaphore.hpp"
+
+CInstanceLock::CInstanceLock() : pLockFolder(getHyprsunsetFolder()) {
+    static constexpr const char* SEM_NAME = "/hyprsunsetsemaphore";
+    CIPCSemaphore                fileSem{SEM_NAME};
+    auto                         fileLock = fileSem.getLock();
+
+    if (!lock()) {
+        Debug::log(NONE, "✖ Failed to set instance lock {}", pLockFolder.c_str());
+        return;
+    }
+
+    isOnlyInstance = true;
+}
+
+CInstanceLock::~CInstanceLock() {
+    unlock();
+}
+
+bool CInstanceLock::lock() {
+    auto ids = readLocks();
+
+    auto sameEnvIt = findSameEnv(ids);
+
+    if (sameEnvIt != ids.end()) {
+        pid_t oldPid = sameEnvIt->pid;
+
+        if (!killOld(oldPid))
+            return false;
+    }
+
+    writeLock();
+
+    return true;
+}
+
+void CInstanceLock::unlock() {
+    std::filesystem::remove(getLockFile(pIdentifer.pid));
+}
+
+void CInstanceLock::writeLock() {
+    std::ofstream f{getLockFile(pIdentifer.pid), std::fstream::out | std::fstream::trunc};
+    f << pIdentifer.toString();
+}
+
+std::vector<CInstanceLock::SInstanceIdentifier> CInstanceLock::readLocks() {
+    std::vector<CInstanceLock::SInstanceIdentifier> ids;
+
+    for (const auto& file : std::filesystem::recursive_directory_iterator(pLockFolder)) {
+        ids.emplace_back(readFile(file).value_or(CInstanceLock::SInstanceIdentifier{}));
+    }
+
+    return ids;
+}
+
+std::optional<CInstanceLock::SInstanceIdentifier> CInstanceLock::readFile(const std::filesystem::directory_entry& file) {
+    if (!file.is_regular_file())
+        return std::nullopt;
+
+    pid_t         pid = 0;
+    std::string   waylandEnv;
+
+    std::ifstream f{file.path(), std::fstream::in};
+    f >> pid >> waylandEnv;
+
+    return CInstanceLock::SInstanceIdentifier{pid, std::move(waylandEnv)};
+}
+
+bool CInstanceLock::killOld(pid_t oldPid) {
+    if (oldPid <= 0)
+        return false;
+
+    if (kill(oldPid, SIGTERM) == -1) {
+        Debug::log(NONE, "✖ Failed to to kill the other running instance: {}", strerror(errno));
+        return false;
+    }
+
+    while (isProcessAlive(oldPid)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    return true;
+}
+
+bool CInstanceLock::isProcessAlive(pid_t pid) {
+    return kill(pid, 0) == 0 || errno != ESRCH;
+}
+
+std::vector<CInstanceLock::SInstanceIdentifier>::iterator CInstanceLock::findSameEnv(std::vector<SInstanceIdentifier>& ids) {
+    return std::ranges::find_if(std::views::all(ids), [this](const CInstanceLock::SInstanceIdentifier& id) { return id.waylandEnv == pIdentifer.waylandEnv; });
+}
+
+std::vector<CInstanceLock::SInstanceIdentifier>::iterator CInstanceLock::findUs(std::vector<SInstanceIdentifier>& ids) {
+    return std::ranges::find_if(std::views::all(ids), [this](const CInstanceLock::SInstanceIdentifier& id) { return id == pIdentifer; });
+}
+
+std::filesystem::path CInstanceLock::getLockFile(pid_t pid) {
+    return pLockFolder.string() + '/' + std::to_string(pid);
+}
+
+CInstanceLock::CInstanceLock::SInstanceIdentifier CInstanceLock::getInstanceIdentifier() {
+    int pid = getpid();
+    if (pid == -1) {
+        Debug::log(NONE, "✖ Failed to get proccess id. How could it happen...: {}", strerror(errno));
+        return {-1, {}};
+    }
+
+    const char* display = getenv("WAYLAND_DISPLAY");
+    if (!display) {
+        Debug::log(NONE, "✖ Failed to get the current wayland display. Is a wayland compositor running?");
+        return {-1, {}};
+    }
+
+    return {pid, display};
+}
+
+std::string CInstanceLock::CInstanceLock::SInstanceIdentifier::toString() const {
+    return std::format("{}\n{}\n", pid, waylandEnv);
+}
+
+bool CInstanceLock::CInstanceLock::SInstanceIdentifier::operator==(const SInstanceIdentifier& other) const {
+    return pid == other.pid && waylandEnv == other.waylandEnv;
+}

--- a/src/InstanceLock.hpp
+++ b/src/InstanceLock.hpp
@@ -1,39 +1,14 @@
 #pragma once
 
-#include <algorithm>
-#include <cerrno>
-#include <chrono>
-#include <cstring>
-#include <fstream>
 #include <filesystem>
-#include <iostream>
-#include <ranges>
-#include <thread>
+#include <string>
+#include <vector>
 #include <wait.h>
-
-#include "helpers/Log.hpp"
-#include "helpers/GetRuntimeDir.hpp"
-
-#include "IPCSemaphore.hpp"
 
 class CInstanceLock {
   public:
-    CInstanceLock() : pLockFolder(getHyprsunsetFolder()) {
-        static constexpr const char* SEM_NAME = "/hyprsunsetsemaphore";
-        IPCSemaphore                 fileSem{SEM_NAME};
-        auto                         fileLock = fileSem.getLock();
-
-        if (!lock()) {
-            Debug::log(NONE, "✖ Failed to set instance lock {}", pLockFolder.c_str());
-            return;
-        }
-
-        isOnlyInstance = true;
-    }
-
-    ~CInstanceLock() {
-        unlock();
-    }
+    CInstanceLock();
+    ~CInstanceLock();
 
     bool isOnlyInstance = false;
 
@@ -45,13 +20,9 @@ class CInstanceLock {
         SInstanceIdentifier() = default;
         SInstanceIdentifier(pid_t pid, std::string&& display) : pid(pid), waylandEnv(std::move(display)) {}
 
-        std::string toString() const {
-            return std::format("{}\n{}\n", pid, waylandEnv);
-        }
+        std::string toString() const;
 
-        bool operator==(const SInstanceIdentifier& other) const {
-            return pid == other.pid && waylandEnv == other.waylandEnv;
-        }
+        bool        operator==(const SInstanceIdentifier& other) const;
     };
 
   private:
@@ -59,101 +30,15 @@ class CInstanceLock {
     SInstanceIdentifier   pIdentifer{getInstanceIdentifier()};
 
   private:
-    bool lock() {
-        auto ids = readLocks();
-
-        auto sameEnvIt = findSameEnv(ids);
-
-        if (sameEnvIt != ids.end()) {
-            pid_t oldPid = sameEnvIt->pid;
-
-            if (!killOld(oldPid))
-                return false;
-        }
-
-        writeLock();
-
-        return true;
-    }
-
-    void unlock() {
-        std::filesystem::remove(getLockFile(pIdentifer.pid));
-    }
-
-    std::vector<SInstanceIdentifier> readLocks() {
-        std::vector<SInstanceIdentifier> ids;
-
-        for (const auto& file : std::filesystem::recursive_directory_iterator(pLockFolder)) {
-            ids.emplace_back(readFile(file).value_or(SInstanceIdentifier{}));
-        }
-
-        return ids;
-    }
-
-    void writeLock() {
-        std::ofstream f{getLockFile(pIdentifer.pid), std::fstream::out | std::fstream::trunc};
-        f << pIdentifer.toString();
-    }
-
-    std::optional<SInstanceIdentifier> readFile(const std::filesystem::directory_entry& file) {
-        if (!file.is_regular_file())
-            return std::nullopt;
-
-        pid_t         pid = 0;
-        std::string   waylandEnv;
-
-        std::ifstream f{file.path(), std::fstream::in};
-        f >> pid >> waylandEnv;
-
-        return SInstanceIdentifier{pid, std::move(waylandEnv)};
-    }
-
-    static bool killOld(pid_t oldPid) {
-        if (oldPid <= 0)
-            return false;
-
-        if (kill(oldPid, SIGTERM) == -1) {
-            Debug::log(NONE, "✖ Failed to to kill the other running instance: {}", strerror(errno));
-            return false;
-        }
-
-        while (isProcessAlive(oldPid)) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        }
-
-        return true;
-    }
-
-    static bool isProcessAlive(pid_t pid) {
-        return kill(pid, 0) == 0 || errno != ESRCH;
-    }
-
-    std::vector<SInstanceIdentifier>::iterator findSameEnv(std::vector<SInstanceIdentifier>& ids) {
-        return std::ranges::find_if(std::views::all(ids), [this](const SInstanceIdentifier& id) { return id.waylandEnv == pIdentifer.waylandEnv; });
-    }
-
-    std::vector<SInstanceIdentifier>::iterator findUs(std::vector<SInstanceIdentifier>& ids) {
-        return std::ranges::find_if(std::views::all(ids), [this](const SInstanceIdentifier& id) { return id == pIdentifer; });
-    }
-
-    std::filesystem::path getLockFile(pid_t pid) {
-        return pLockFolder.string() + '/' + std::to_string(pid);
-    }
-
-    // returns pid and WAYLAND_DISPLAY
-    static SInstanceIdentifier getInstanceIdentifier() {
-        int pid = getpid();
-        if (pid == -1) {
-            Debug::log(NONE, "✖ Failed getpid: {}", strerror(errno));
-            return {-1, {}};
-        }
-
-        const char* display = getenv("WAYLAND_DISPLAY");
-        if (!display) {
-            Debug::log(NONE, "✖ Failed getenv(\"WAYLAND_DISPLAY\"): {}", strerror(errno));
-            return {-1, {}};
-        }
-
-        return {pid, display};
-    }
+    bool                                       lock();
+    void                                       unlock();
+    std::vector<SInstanceIdentifier>           readLocks();
+    void                                       writeLock();
+    std::optional<SInstanceIdentifier>         readFile(const std::filesystem::directory_entry& file);
+    static bool                                killOld(pid_t oldPid);
+    static bool                                isProcessAlive(pid_t pid);
+    std::vector<SInstanceIdentifier>::iterator findSameEnv(std::vector<SInstanceIdentifier>& ids);
+    std::vector<SInstanceIdentifier>::iterator findUs(std::vector<SInstanceIdentifier>& ids);
+    std::filesystem::path                      getLockFile(pid_t pid);
+    static SInstanceIdentifier                 getInstanceIdentifier();
 };

--- a/src/InstanceLock.hpp
+++ b/src/InstanceLock.hpp
@@ -1,0 +1,122 @@
+#include <cerrno>
+#include <cstring>
+#include <signal.h>
+#include <sys/file.h>
+#include <thread>
+#include <unistd.h>
+#include <wait.h>
+
+class InstanceLock {
+public:
+    InstanceLock() : pPid(getpid()) {
+        using namespace std::chrono_literals;
+
+        pFd = open(pLockName.c_str(), O_CREAT | O_RDWR, 0666);
+
+        if (pFd == -1) {
+            int         ern       = errno;
+            const char* ernString = strerror(ern);
+            Debug::log(NONE, "Failed to open instance lock {}: {}", pLockName, ernString);
+            return; // it is not the only instance
+        }
+
+        constexpr int MAX_TRIES = 50;
+        int           i         = 0;
+
+        while (i < MAX_TRIES && !tryLock()) {
+            i++;
+            std::this_thread::sleep_for(1000ms);
+        }
+
+        if (i == MAX_TRIES) {
+            Debug::log(NONE, "Failed to set instance lock {}", pLockName);
+            return; // it is not the only instance
+        }
+
+        if (write(pFd, &pPid, sizeof(pPid)) == -1) {
+            int         ern       = errno;
+            const char* ernString = strerror(ern);
+            Debug::log(NONE, "Failed to write current pid to lock file: {}", ernString);
+        }
+
+        // without sleep the color stays as if no filter was applied
+        std::this_thread::sleep_for(100ms);
+        isOnlyInstance = true;
+    }
+
+    ~InstanceLock() {
+        unlock();
+    }
+
+    bool isOnlyInstance = false;
+
+  private:
+    pid_t pPid = -1;
+    int   pFd  = -1;
+
+  private:
+    static constexpr const char* pLockName = "/tmp/hyprsunsetlockfile";
+
+  private:
+    bool tryLock() {
+        if (flock(pFd, LOCK_EX | LOCK_NB) == -1) {
+            // it will never kill old then
+            if (!killOld())
+                return false;
+        }
+
+        Debug::log(INFO, "Acquired lock");
+
+        return true;
+    }
+
+    void unlock() {
+        if (flock(pFd, LOCK_UN) == -1) {
+            int         ern       = errno;
+            const char* ernString = strerror(ern);
+            Debug::log(NONE, "Failed to unlock the instance {}: {}", pLockName, ernString);
+        }
+
+        if (close(pFd) == -1) {
+            int         ern       = errno;
+            const char* ernString = strerror(ern);
+            Debug::log(NONE, "Failed to close lock fd {}: {}", pLockName, ernString);
+        }
+
+        Debug::log(INFO, "Unlocked");
+    }
+
+    bool killOld() {
+        pid_t oldPid = getOldPid();
+        Debug::log(INFO, "oldPid: {}", oldPid);
+        if (oldPid == -1)
+            return false;
+
+        if (kill(oldPid, SIGTERM) == -1) {
+            int         ern       = errno;
+            const char* ernString = strerror(ern);
+            Debug::log(NONE, "Failed to to kill the other running instance: {}", ernString);
+
+            return false;
+        }
+
+        waitpid(oldPid, nullptr, 0);
+
+        Debug::log(INFO, "Killed: {}", oldPid);
+
+        return true;
+    }
+
+    pid_t getOldPid() {
+        pid_t oldPid = 0;
+        if (read(pFd, &oldPid, sizeof(oldPid)) == -1) {
+            int         ern       = errno;
+            const char* ernString = strerror(ern);
+            Debug::log(NONE, "Failed to read pid of the other running instance: {}", ernString);
+
+            return -1;
+        }
+
+        return oldPid;
+    }
+};

--- a/src/InstanceLock.hpp
+++ b/src/InstanceLock.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <vector>
 #include <wait.h>

--- a/src/helpers/GetRuntimeDir.cpp
+++ b/src/helpers/GetRuntimeDir.cpp
@@ -1,0 +1,41 @@
+#include <fcntl.h>
+#include <pwd.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "Log.hpp"
+#include "GetRuntimeDir.hpp"
+
+// taken from Hyprland/hyprctl/main.cpp
+static  unsigned getUID() {
+    const auto UID   = getuid();
+    const auto PWUID = getpwuid(UID);
+    return PWUID ? PWUID->pw_uid : UID;
+}
+
+static std::filesystem::path getRuntimeDir() {
+    const auto XDG = getenv("XDG_RUNTIME_DIR");
+
+    if (!XDG) {
+        const auto USERID = std::to_string(getUID());
+        return "/run/user/" + USERID + "/hypr";
+    }
+
+    return std::string{XDG} + "/hypr";
+}
+
+std::filesystem::path getHyprsunsetFolder() {
+    std::filesystem::path lockFolder = getRuntimeDir();
+    lockFolder += "/hyprsunset";
+
+    if (!std::filesystem::exists(lockFolder)) {
+        std::error_code e;
+        std::filesystem::create_directory(lockFolder, e);
+        if (e) {
+            Debug::log(NONE, "✖ Failed to create {} folder: {}", lockFolder.string(), e.message());
+            return {};
+        }
+    }
+
+    return lockFolder;
+}

--- a/src/helpers/GetRuntimeDir.cpp
+++ b/src/helpers/GetRuntimeDir.cpp
@@ -7,7 +7,7 @@
 #include "GetRuntimeDir.hpp"
 
 // taken from Hyprland/hyprctl/main.cpp
-static  unsigned getUID() {
+static unsigned getUID() {
     const auto UID   = getuid();
     const auto PWUID = getpwuid(UID);
     return PWUID ? PWUID->pw_uid : UID;
@@ -28,12 +28,18 @@ std::filesystem::path getHyprsunsetFolder() {
     std::filesystem::path lockFolder = getRuntimeDir();
     lockFolder += "/hyprsunset";
 
-    if (!std::filesystem::exists(lockFolder)) {
-        std::error_code e;
-        std::filesystem::create_directory(lockFolder, e);
-        if (e) {
-            Debug::log(NONE, "✖ Failed to create {} folder: {}", lockFolder.string(), e.message());
+    std::error_code errexists;
+    if (!std::filesystem::exists(lockFolder, errexists)) {
+        if (errexists) {
+            Debug::log(NONE, "✖ Failed to check if {} exists: {}", lockFolder.string(), errexists.message());
             return {};
+        } else {
+            std::error_code errcreate;
+            std::filesystem::create_directory(lockFolder, errcreate);
+            if (errcreate) {
+                Debug::log(NONE, "✖ Failed to create {} folder: {}", lockFolder.string(), errcreate.message());
+                return {};
+            }
         }
     }
 

--- a/src/helpers/GetRuntimeDir.hpp
+++ b/src/helpers/GetRuntimeDir.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <filesystem>
+
+std::filesystem::path getHyprsunsetFolder();

--- a/src/helpers/Log.hpp
+++ b/src/helpers/Log.hpp
@@ -3,6 +3,7 @@
 #include <format>
 #include <fstream>
 #include <string>
+#include <iostream>
 
 enum LogLevel {
     NONE = -1,

--- a/src/helpers/Log.hpp
+++ b/src/helpers/Log.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <format>
 #include <fstream>
 #include <string>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ struct {
     std::vector<SP<SOutput>>          outputs;
     bool                              initialized = false;
     Mat3x3                            ctm;
-    InstanceLock                      instLock;
+    CInstanceLock                      instLock;
 } state;
 
 void sigHandler(int sig) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,7 @@ struct {
     std::vector<SP<SOutput>>          outputs;
     bool                              initialized = false;
     Mat3x3                            ctm;
-    CInstanceLock                      instLock;
+    CInstanceLock                     instLock;
 } state;
 
 void sigHandler(int sig) {


### PR DESCRIPTION
Add InstanceLock which is an RAII class that acquires a lock as a file. When new instances of hyprsunset are run it kills the old instance and acquires the lock. On fails to access the lock file or acquiring the lock(killing old instance) it logs and exits.

Lock is a file /tmp/hyprsunsetlockfile. When an instance is spawn it tries to flock the file. If it succeeds it writes its pid to the file. If it fails then another instance already has it so the new one reads the old instance pid and tries to kill it. On success it acquires the lock and after that everything is cool.

https://github.com/hyprwm/hyprsunset/issues/10

I added signal(SIGINT...) because pressing ctrl + c sends SIGINT