### PR TITLE
Don't crash when given bad input via IPC

### DIFF
--- a/src/IPCSocket.cpp
+++ b/src/IPCSocket.cpp
@@ -151,23 +151,21 @@ bool CIPCSocket::mainThreadParseRequest() {
 
         std::string        args   = copy.substr(spaceSeparator + 1);
         unsigned long long kelvin = g_pHyprsunset->KELVIN;
-        if (args[0] == '+' || args[0] == '-') {
-            try {
+        try {
+            if (args[0] == '+' || args[0] == '-') {
                 if (args[0] == '-')
                     kelvin -= std::stoull(args.substr(1));
                 else
                     kelvin += std::stoull(args.substr(1));
-            } catch (std::exception& e) {
-                m_szReply = "Invalid temperature (should be in range 1000-20000)";
-                return false;
-            }
-
-            kelvin = std::clamp(kelvin, 1000ull, 20000ull);
-        } else
-            kelvin = std::stoull(args);
-
+                kelvin = std::clamp(kelvin, 1000ull, 20000ull);
+            } else
+                kelvin = std::stoull(args);
+        } catch (std::exception& e) {
+            m_szReply = "Invalid temperature (should be an integer in range 1000-20000)";
+            return false;
+        }
         if (kelvin < 1000 || kelvin > 20000) {
-            m_szReply = "Invalid temperature (should be in range 1000-20000)";
+            m_szReply = "Invalid temperature (should be an integer in range 1000-20000)";
             return false;
         }
 


### PR DESCRIPTION
Right now calling `hyprctl hyprsunset temperature +ilovex11` would just result with an error, but `hyprctl hyprsunset temperature ilovex11` would crash hyprsunset due to uncaught error while parsing. This PR unifies behaviours and now both result in error.