### PR TITLE
core: fix scheduling

### DIFF
--- a/src/Hyprsunset.cpp
+++ b/src/Hyprsunset.cpp
@@ -163,6 +163,7 @@ int CHyprsunset::init() {
 
     state.timerFD = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
 
+    schedule();
     startEventLoop();
 
     return 1;


### PR DESCRIPTION
Looks like the call to `schedule()` got lost at some point in #41. Works as expected by just adding it back. Fix #49.