### PR TITLE
support `source` option for additional config files

### DIFF
--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -5,6 +5,10 @@
 #include <string>
 #include <sys/ucontext.h>
 #include "helpers/Log.hpp"
+#include "helpers/MiscFunctions.hpp"
+#include <glob.h>
+#include <cstring>
+#include <filesystem>
 
 static std::string getMainConfigPath() {
     static const auto paths = Hyprutils::Path::findConfig("hyprsunset");
@@ -17,6 +21,18 @@ CConfigManager::CConfigManager(std::string configPath) :
     currentConfigPath = configPath.empty() ? getMainConfigPath() : configPath;
 }
 
+static Hyprlang::CParseResult handleSource(const char* c, const char* v) {
+    const std::string      VALUE   = v;
+    const std::string      COMMAND = c;
+
+    const auto             RESULT = g_pConfigManager->handleSource(COMMAND, VALUE);
+
+    Hyprlang::CParseResult result;
+    if (RESULT.has_value())
+        result.setError(RESULT.value().c_str());
+    return result;
+}
+
 void CConfigManager::init() {
     m_config.addConfigValue("max-gamma", Hyprlang::INT{100});
 
@@ -25,6 +41,12 @@ void CConfigManager::init() {
     m_config.addSpecialConfigValue("profile", "temperature", Hyprlang::INT{6000});
     m_config.addSpecialConfigValue("profile", "gamma", Hyprlang::FLOAT{1.0f});
     m_config.addSpecialConfigValue("profile", "identity", Hyprlang::INT{0});
+
+    // track the file in the circular dependency chain
+    const auto mainConfigPath = getMainConfigPath();
+    alreadyIncludedSourceFiles.insert(std::filesystem::canonical(mainConfigPath));
+
+    m_config.registerHandler(&::handleSource, "source", {.allowFlags = false});
 
     m_config.commence();
 
@@ -93,4 +115,57 @@ float CConfigManager::getMaxGamma() {
     } catch (const std::bad_any_cast& e) {
         RASSERT(false, "Failed to construct max-gamma: {}", e.what()); //
     }
+}
+
+std::optional<std::string> CConfigManager::handleSource(const std::string& command, const std::string& rawpath) {
+    if (rawpath.length() < 2) {
+        return "source path " + rawpath + " bogus!";
+    }
+    std::unique_ptr<glob_t, void (*)(glob_t*)> glob_buf{new glob_t, [](glob_t* g) { globfree(g); }};
+    memset(glob_buf.get(), 0, sizeof(glob_t));
+
+    const auto CURRENTDIR = std::filesystem::path(currentConfigPath).parent_path().string();
+
+    if (auto r = glob(absolutePath(rawpath, CURRENTDIR).c_str(), GLOB_TILDE, nullptr, glob_buf.get()); r != 0) {
+        std::string err = std::format("source= globbing error: {}", r == GLOB_NOMATCH ? "found no match" : GLOB_ABORTED ? "read error" : "out of memory");
+        Debug::log(ERR, "{}", err);
+        return err;
+    }
+
+    for (size_t i = 0; i < glob_buf->gl_pathc; i++) {
+        const auto PATH = absolutePath(glob_buf->gl_pathv[i], CURRENTDIR);
+
+        if (PATH.empty() || PATH == currentConfigPath) {
+            Debug::log(WARN, "source= skipping invalid path");
+            continue;
+        }
+
+        if (std::find(alreadyIncludedSourceFiles.begin(), alreadyIncludedSourceFiles.end(), PATH) != alreadyIncludedSourceFiles.end()) {
+            Debug::log(WARN, "source= skipping already included source file {} to prevent circular dependency", PATH);
+            continue;
+        }
+
+        if (!std::filesystem::is_regular_file(PATH)) {
+            if (std::filesystem::exists(PATH)) {
+                Debug::log(WARN, "source= skipping non-file {}", PATH);
+                continue;
+            }
+
+            Debug::log(ERR, "source= file doesnt exist");
+            return "source file " + PATH + " doesn't exist!";
+        }
+
+        // track the file in the circular dependency chain
+        alreadyIncludedSourceFiles.insert(PATH);
+
+        // allow for nested config parsing
+        auto backupConfigPath = currentConfigPath;
+        currentConfigPath     = PATH;
+
+        m_config.parseFile(PATH.c_str());
+
+        currentConfigPath = backupConfigPath;
+    }
+
+    return {};
 }

--- a/src/ConfigManager.hpp
+++ b/src/ConfigManager.hpp
@@ -3,6 +3,7 @@
 #include "Hyprsunset.hpp"
 #include <hyprlang.hpp>
 #include <vector>
+#include <set>
 
 class CConfigManager {
   public:
@@ -13,10 +14,13 @@ class CConfigManager {
 
     void                        init();
 
-  private:
-    Hyprlang::CConfig m_config;
+    std::optional<std::string>  handleSource(const std::string&, const std::string&);
 
-    std::string       currentConfigPath;
+  private:
+    Hyprlang::CConfig           m_config;
+
+    std::string                 currentConfigPath;
+    std::set<std::string>       alreadyIncludedSourceFiles;
 };
 
 inline UP<CConfigManager> g_pConfigManager;

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -1,0 +1,19 @@
+#include <filesystem>
+
+#include "MiscFunctions.hpp"
+
+std::string absolutePath(const std::string& rawpath, const std::string& currentDir) {
+    std::filesystem::path path(rawpath);
+
+    // Handling where rawpath starts with '~'
+    if (!rawpath.empty() && rawpath[0] == '~') {
+        static const char* const ENVHOME = getenv("HOME");
+        path                             = std::filesystem::path(ENVHOME) / path.relative_path().string().substr(2);
+    }
+
+    // Handling e.g. ./, ../
+    if (path.is_relative())
+        return std::filesystem::weakly_canonical(std::filesystem::path(currentDir) / path);
+    else
+        return std::filesystem::weakly_canonical(path);
+}

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string>
+
+std::string absolutePath(const std::string&, const std::string&);


### PR DESCRIPTION
Hello there.

This PR implements a new config key : `source`. It's used to load other config files.

The idea is to be able to split the config over multiple files, or (in my case) to load a "default" one and override it later if needed.

It matches the behaviour in hyprland.conf and multiple other hyprland utilities.

The code is blatantly taken from this [hypridle PR](https://github.com/hyprwm/hypridle/pull/144), which in turn took it from hyprlock.

I have to confess I didn't test it, as I'm not running hyprland at the moment and cannot install the require librairies to build this.

I believe it should work, but if someone can chime in to verify this claim I'd appreciate it.