### PR TITLE
Fix systemd unit install directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,4 +140,10 @@ endif()
 include(GNUInstallDirs)
 
 install(TARGETS hyprsunset)
-install(FILES ${CMAKE_BINARY_DIR}/systemd/hyprsunset.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/user)
+
+pkg_get_variable(SYSTEMD_USER_UNIT_DIR systemd systemduserunitdir)
+if (NOT SYSTEMD_USER_UNIT_DIR)
+  set(SYSTEMD_USER_UNIT_DIR "${CMAKE_INSTALL_PREFIX}/lib/systemd/user")
+endif()
+
+install(FILES ${CMAKE_BINARY_DIR}/systemd/hyprsunset.service DESTINATION "${SYSTEMD_USER_UNIT_DIR}")


### PR DESCRIPTION
### Summary
This PR fixes the installation path of the `hyprsunset.service` systemd user unit. Previously the build used:

```cmake
install(FILES ${CMAKE_BINARY_DIR}/systemd/hyprsunset.service DESTINATION ${CMAKE_INSTALL_LIBDIR}/systemd/user)
```

This relies on `${CMAKE_INSTALL_LIBDIR}`, which on multilib systems expands to `lib64`. However, systemd *does not* look in `/usr/lib64/systemd/user` for user units. It only searches `/usr/lib/systemd/user`. This means the installed unit file would not be picked up by systemd on such systems.

This is demonstrated when building hyprsunset on Gentoo here:
[attached build.log](https://gist.github.com/peppapig450/c7bde00ae162a7128c63308166f56732)

### The Fix
Instead of guessing the correct path,This PR uses the value provided by systemd’s `pkg-config` file, with a fallback to `${CMAKE_INSTALL_PREFIX}/lib/systemd/user` if the variable is unavailable, which is the recommended approach upstream:

> "At the build installation time (e.g. make install during package build), packages are recommended to install their systemd unit files in the directory returned by `pkg-config systemd --variable=systemdsystemunitdir` (for system services) or `pkg-config systemd --variable=systemduserunitdir` (for user services). "
— [systemd documentation](https://www.freedesktop.org/software/systemd/man/latest/daemon.html) 
---
If you'd like me to tweak the commit message, provide further build logs, adjust style or do anything differently just let me know!