### PR TITLE
core: added resetting to current profile (#52)

### DIFF
--- a/src/Hyprsunset.cpp
+++ b/src/Hyprsunset.cpp
@@ -330,6 +330,10 @@ int CHyprsunset::currentProfile() {
     return profiles.size() - 1;
 }
 
+SSunsetProfile CHyprsunset::getCurrentProfile() {
+    return profiles[currentProfile()];
+}
+
 void CHyprsunset::schedule() {
     std::thread([&]() {
         while (true) {
@@ -344,10 +348,10 @@ void CHyprsunset::schedule() {
 
             if (now >= time)
                 time += std::chrono::days(1);
-            
+
             while (time >= std::chrono::zoned_time(std::chrono::current_zone(), std::chrono::system_clock::now()).get_local_time() + std::chrono::minutes(1))
                 std::this_thread::sleep_for(std::chrono::minutes(1));
-            
+
             auto system_time = std::chrono::zoned_time{std::chrono::current_zone(), time}.get_sys_time();
 
             std::this_thread::sleep_until(system_time);
@@ -356,7 +360,7 @@ void CHyprsunset::schedule() {
             if (newcurrent == -1)
                 break;
 
-            SSunsetProfile newProfile = profiles[newcurrent];
+            SSunsetProfile              newProfile = profiles[newcurrent];
 
             std::lock_guard<std::mutex> lg(m_sEventLoopInternals.loopRequestMutex);
             KELVIN   = newProfile.temperature;

--- a/src/Hyprsunset.hpp
+++ b/src/Hyprsunset.hpp
@@ -55,6 +55,7 @@ class CHyprsunset {
     int                init();
     void               tick();
     void               loadCurrentProfile();
+    SSunsetProfile     getCurrentProfile();
     void               terminate();
 
     struct {

--- a/src/IPCSocket.cpp
+++ b/src/IPCSocket.cpp
@@ -180,6 +180,34 @@ bool CIPCSocket::mainThreadParseRequest() {
         return true;
     }
 
+    if (copy.find("reset") == 0) {
+        int spaceSeparator = copy.find_first_of(' ');
+
+        // Reset whole profile
+        if (spaceSeparator == -1) {
+            g_pHyprsunset->loadCurrentProfile();
+            return true;
+        }
+
+        SSunsetProfile profile = g_pHyprsunset->getCurrentProfile();
+
+        std::string    args = copy.substr(spaceSeparator + 1);
+
+        if (args == "temperature") {
+            g_pHyprsunset->KELVIN = profile.temperature;
+            return true;
+        } else if (args == "gamma") {
+            g_pHyprsunset->GAMMA = profile.gamma;
+            return true;
+        } else if (args == "identity") {
+            g_pHyprsunset->identity = profile.identity;
+            return true;
+        } else {
+            m_szReply = "Invalid reset value (should be either temperature, gamma or identity)";
+            return false;
+        }
+    }
+
     m_szReply = "invalid command";
     return false;
 }


### PR DESCRIPTION
I've added `reset` as an IPC request which resets the current config back to the current profile, it can reset to the whole profile or temperature, gamma or identity individually.
```
hyprctl hyprsunset reset
hyprctl hyprsunset reset temperature
hyprctl hyprsunset reset gamma
hyprctl hyprsunset reset identity
```

I can also add some documentation to the wiki too.