### PR TITLE
ipc: fix crash in reset & profile with 0 profiles

### DIFF
--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -59,15 +59,17 @@ std::vector<SSunsetProfile> CConfigManager::getSunsetProfiles() {
 
         size_t separator = time.find(':');
 
-        if (separator == std::string::npos)
-            RASSERT(false, "Invalid time format for profile {}", key);
+        if (separator == std::string::npos) {
+            Debug::log(ERR, "Invalid time format: {}, skipping profile {}", time, key);
+            continue;
+        }
 
         int hour = 0, minute = 0;
         try {
             hour   = std::stoi(time.substr(0, separator));
             minute = std::stoi(time.substr(separator + 1).c_str());
         } catch (const std::exception& e) {
-            Debug::log(ERR, "Invalid time format: {}, skipping this profile", time);
+            Debug::log(ERR, "Invalid time format: {}, skipping profile {}", time, key);
             continue;
         }
 

--- a/src/Hyprsunset.cpp
+++ b/src/Hyprsunset.cpp
@@ -3,6 +3,7 @@
 #include "IPCSocket.hpp"
 #include <cstring>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <chrono>
 #include <sys/poll.h>
@@ -103,7 +104,7 @@ int CHyprsunset::init() {
     state.wlDisplay = wl_display_connect(nullptr);
 
     if (!state.wlDisplay) {
-        Debug::log(NONE, "✖ Couldn't connect to a wayland compositor", KELVIN);
+        Debug::log(NONE, "✖ Couldn't connect to a wayland compositor");
         return 0;
     }
 
@@ -133,7 +134,7 @@ int CHyprsunset::init() {
                 makeShared<SOutput>(makeShared<CCWlOutput>((wl_proxy*)wl_registry_bind((wl_registry*)state.pRegistry->resource(), name, &wl_output_interface, 3)), name));
 
             if (state.initialized) {
-                Debug::log(NONE, "┣ already initialized, applying CTM instantly", name);
+                Debug::log(NONE, "┣ already initialized, applying CTM instantly");
                 o->applyCTM(&state);
                 commitCTMs();
             }
@@ -145,7 +146,7 @@ int CHyprsunset::init() {
     wl_display_roundtrip(state.wlDisplay);
 
     if (!state.pCTMMgr) {
-        Debug::log(NONE, "✖ Compositor doesn't support hyprland-ctm-control-v1, are you running on Hyprland?", KELVIN);
+        Debug::log(NONE, "✖ Compositor doesn't support hyprland-ctm-control-v1, are you running on Hyprland?");
         return 0;
     }
 
@@ -330,8 +331,12 @@ int CHyprsunset::currentProfile() {
     return profiles.size() - 1;
 }
 
-SSunsetProfile CHyprsunset::getCurrentProfile() {
-    return profiles[currentProfile()];
+std::optional<SSunsetProfile> CHyprsunset::getCurrentProfile() {
+    int current = currentProfile();
+    if (current < 0)
+        return std::nullopt;
+
+    return profiles[current];
 }
 
 void CHyprsunset::schedule() {

--- a/src/Hyprsunset.hpp
+++ b/src/Hyprsunset.hpp
@@ -3,6 +3,7 @@
 #include <wayland-client.h>
 #include <vector>
 #include <mutex>
+#include <optional>
 #include <condition_variable>
 #include "protocols/hyprland-ctm-control-v1.hpp"
 #include "protocols/wayland.hpp"
@@ -44,19 +45,19 @@ struct SSunsetProfile {
 
 class CHyprsunset {
   public:
-    float              MAX_GAMMA = 1.0f; // default
-    float              GAMMA     = 1.0f; // default
-    unsigned long long KELVIN    = 6000; // default
-    bool               kelvinSet = false, identity = false;
-    SState             state;
-    bool               m_bTerminate = false;
+    float                         MAX_GAMMA = 1.0f; // default
+    float                         GAMMA     = 1.0f; // default
+    unsigned long long            KELVIN    = 6000; // default
+    bool                          kelvinSet = false, identity = false;
+    SState                        state;
+    bool                          m_bTerminate = false;
 
-    int                calculateMatrix();
-    int                init();
-    void               tick();
-    void               loadCurrentProfile();
-    SSunsetProfile     getCurrentProfile();
-    void               terminate();
+    int                           calculateMatrix();
+    int                           init();
+    void                          tick();
+    void                          loadCurrentProfile();
+    std::optional<SSunsetProfile> getCurrentProfile();
+    void                          terminate();
 
     struct {
         std::condition_variable loopSignal;

--- a/src/IPCSocket.cpp
+++ b/src/IPCSocket.cpp
@@ -207,37 +207,43 @@ bool CIPCSocket::mainThreadParseRequest() {
             return true;
         }
 
-        SSunsetProfile profile = g_pHyprsunset->getCurrentProfile();
+        if (auto profileOpt = g_pHyprsunset->getCurrentProfile()) {
+            auto        profile = profileOpt.value();
+            std::string args    = copy.substr(spaceSeparator + 1);
 
-        std::string    args = copy.substr(spaceSeparator + 1);
-
-        if (args == "temperature") {
-            g_pHyprsunset->KELVIN = profile.temperature;
-            return true;
-        } else if (args == "gamma") {
-            g_pHyprsunset->GAMMA = profile.gamma;
-            return true;
-        } else if (args == "identity") {
-            g_pHyprsunset->identity = profile.identity;
-            return true;
-        } else {
-            m_szReply = "Invalid reset value (should be either temperature, gamma or identity)";
-            return false;
+            if (args == "temperature") {
+                g_pHyprsunset->KELVIN = profile.temperature;
+                return true;
+            } else if (args == "gamma") {
+                g_pHyprsunset->GAMMA = profile.gamma;
+                return true;
+            } else if (args == "identity") {
+                g_pHyprsunset->identity = profile.identity;
+                return true;
+            } else {
+                m_szReply = "Invalid reset value (should be either temperature, gamma or identity)";
+                return false;
+            }
         }
+        m_szReply = "No profile is currently loaded";
+        return false;
     }
 
     if (copy.find("profile") == 0) {
-        SSunsetProfile profile = g_pHyprsunset->getCurrentProfile();
+        if (auto profileOpt = g_pHyprsunset->getCurrentProfile()) {
+            auto  profile = profileOpt.value();
 
-        int            hrs   = profile.time.hour.count();
-        int            mins  = profile.time.minute.count();
-        auto           temp  = profile.temperature;
-        float          gamma = profile.gamma;
-        bool           ident = profile.identity;
+            int   hrs   = profile.time.hour.count();
+            int   mins  = profile.time.minute.count();
+            auto  temp  = profile.temperature;
+            float gamma = profile.gamma;
+            bool  ident = profile.identity;
 
-        m_szReply = std::format("Time: {:0>2}:{:0>2}\nTemperature: {}\nGamma: {}\nIdentity: {}", hrs, mins, temp, gamma, ident);
-
-        return true;
+            m_szReply = std::format("Time: {:0>2}:{:0>2}\nTemperature: {}\nGamma: {}\nIdentity: {}", hrs, mins, temp, gamma, ident);
+            return true;
+        }
+        m_szReply = "No profile is currently loaded";
+        return false;
     }
 
     m_szReply = "invalid command";


### PR DESCRIPTION
- fixes crash in `reset` & `profile` when no profiles are present
- skip profile on invalid time instead of crashing
- random typos